### PR TITLE
Improve UX and accessibility for content page

### DIFF
--- a/contents/1/css/style.css
+++ b/contents/1/css/style.css
@@ -80,6 +80,18 @@ textarea {
   color: inherit;
   vertical-align: top;
 }
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* navigation area */
 /* #header {
   position: sticky;
@@ -532,17 +544,24 @@ textarea {
   padding: 80px 12px;
 }
 
-.shopinfo iframe {
-  height: 100%;
-}
-
 .access,
 .contact {
   width: 50%;
+  display: flex;
 }
 
-iframe {
+.map-wrap {
+  position: relative;
   width: 100%;
+  height: 100%;
+}
+
+.map-wrap iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .slider {
@@ -564,10 +583,14 @@ iframe {
   }
   .contact {
     margin-top: 40px;
-    height: 480px;
   }
 
-  iframe {
+  .map-wrap {
+    height: auto;
+    padding-top: 56.25%;
+  }
+
+  .map-wrap iframe {
     width: 100%;
   }
 

--- a/contents/1/index.html
+++ b/contents/1/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>ONE OR SEVEN | 架空のカフェサイト</title>
+    <meta
+      name="description"
+      content="架空のカフェ「ONE OR SEVEN」のメニューや店舗情報を紹介するポートフォリオ用サイトです。"
+    />
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
@@ -12,21 +16,21 @@
       <nav class="navigation">
         <div class="contents">
           <div class="root-link-area">
-            <a href="#">HOME</a>
+            <a href="#mv">HOME</a>
           </div>
           <div class="main-link-area">
-            <a class="main-link" href="#">Menu</a>
-            <a class="main-link" href="#">Point</a>
-            <a class="main-link" href="#">Access</a>
+            <a class="main-link" href="#menu">Menu</a>
+            <a class="main-link" href="#point">Point</a>
+            <a class="main-link" href="#shopinfo">Access</a>
           </div>
           <div class="sub-links-area">
-            <a class="sub-link" href="#">
+            <a class="sub-link" href="tel:090-0000-0000">
               <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#fff">
                 <path
                   d="M798-120q-125 0-247-54.5T329-329Q229-429 174.5-551T120-798q0-18 12-30t30-12h162q14 0 25 9.5t13 22.5l26 140q2 16-1 27t-11 19l-97 98q20 37 47.5 71.5T387-386q31 31 65 57.5t72 48.5l94-94q9-9 23.5-13.5T670-390l138 28q14 4 23 14.5t9 23.5v162q0 18-12 30t-30 12ZM241-600l66-66-17-94h-89q5 41 14 81t26 79Zm358 358q39 17 79.5 27t81.5 13v-88l-94-19-67 67ZM241-600Zm358 358Z"
                 />
               </svg>
-              :09-0000-0000</a
+              <span class="visually-hidden">TEL:</span>090-0000-0000</a
             >
           </div>
         </div>
@@ -136,7 +140,7 @@
         <h2>POINT</h2>
         <div class="point-wrap">
           <p class="point-image">
-            <img src="./img/01.jpg" alt="" width="850px" height="500px" />
+            <img src="./img/01.jpg" alt="焼きたてのパイが並ぶショーケース" />
           </p>
           <dl class="point-text">
             <dt>名物のパイが食べ放題</dt>
@@ -150,7 +154,7 @@
         </div>
         <div class="point-wrap wrap01">
           <p class="point-image">
-            <img src="./img/03.jpg" alt="" width="850px" height="500px" />
+            <img src="./img/03.jpg" alt="木のテーブルでくつろぐカフェの内観" />
           </p>
           <dl class="point-text">
             <dt>名物のパイが食べ放題</dt>
@@ -164,7 +168,7 @@
         </div>
         <div class="point-wrap">
           <p class="point-image">
-            <img src="./img/04.jpg" alt="" width="850px" height="500px" />
+            <img src="./img/04.jpg" alt="コーヒーとデザートが並ぶテーブル" />
           </p>
           <dl class="point-text">
             <dt>名物のパイが食べ放題</dt>
@@ -216,15 +220,15 @@
               </dl>
             </div>
             <div class="contact">
-              <iframe
-                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28483.19009945388!2d128.27220748652564!3d26.827266408667985!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x34e46b6ed93a80c9%3A0x9506eb49b0f5de7b!2z44CSOTA1LTE1MDEg5rKW57iE55yM5Zu96aCt6YOh5Zu96aCt5p2R5aWl!5e0!3m2!1sja!2sjp!4v1753405333101!5m2!1sja!2sjp"
-                width="600"
-                height="450"
-                style="border: 0"
-                allowfullscreen=""
-                loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade"
-              ></iframe>
+              <div class="map-wrap">
+                <iframe
+                  src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d28483.19009945388!2d128.27220748652564!3d26.827266408667985!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x34e46b6ed93a80c9%3A0x9506eb49b0f5de7b!2z44CSOTA1LTE1MDEg5rKW57iE55yM5Zu96aCt6YOh5Zu96aCt5p2R5aWl!5e0!3m2!1sja!2sjp!4v1753405333101!5m2!1sja!2sjp"
+                  style="border: 0"
+                  allowfullscreen=""
+                  loading="lazy"
+                  referrerpolicy="no-referrer-when-downgrade"
+                ></iframe>
+              </div>
             </div>
           </div>
         </div>
@@ -236,22 +240,22 @@
                   <div class="slider-track">
                     <div class="slider-items">
                       <div class="slider-slide">
-                        <div class="slider-image"><img src="img/01.jpg" alt="ヴェネツィアの静かな運河沿いの街並みと停泊するボート、左手にはカフェでくつろぐ人々の姿" /></div>
+                        <div class="slider-image"><img src="img/01.jpg" alt="運河沿いのカフェとボート" /></div>
                       </div>
                       <div class="slider-slide">
-                        <div class="slider-image"><img src="img/02.jpg" alt="ヴェネツィアの静かな運河沿いの街並みと停泊するボート、左手にはカフェでくつろぐ人々の姿" /></div>
+                        <div class="slider-image"><img src="img/02.jpg" alt="夕暮れ時の運河と建物" /></div>
                       </div>
                       <div class="slider-slide">
-                        <div class="slider-image"><img src="img/03.jpg" alt="ヴェネツィアの静かな運河沿いの街並みと停泊するボート、左手にはカフェでくつろぐ人々の姿" /></div>
+                        <div class="slider-image"><img src="img/03.jpg" alt="朝日に照らされた運河" /></div>
                       </div>
                       <div class="slider-slide">
-                        <div class="slider-image"><img src="img/04.jpg" alt="ヴェネツィアの静かな運河沿いの街並みと停泊するボート、左手にはカフェでくつろぐ人々の姿" /></div>
+                        <div class="slider-image"><img src="img/04.jpg" alt="水面に映る街並み" /></div>
                       </div>
                       <div class="slider-slide">
-                        <div class="slider-image"><img src="img/05.jpg" alt="ヴェネツィアの静かな運河沿いの街並みと停泊するボート、左手にはカフェでくつろぐ人々の姿" /></div>
+                        <div class="slider-image"><img src="img/05.jpg" alt="夜の運河とライトアップ" /></div>
                       </div>
                       <div class="slider-slide">
-                        <div class="slider-image"><img src="img/01.jpg" alt="ヴェネツィアの静かな運河沿いの街並みと停泊するボート、左手にはカフェでくつろぐ人々の姿" /></div>
+                        <div class="slider-image"><img src="img/01.jpg" alt="" aria-hidden="true" /></div>
                       </div>
                     </div>
                   </div>
@@ -308,7 +312,7 @@
         <div class="copyright">Copyright (c) 2025 test, Inc. All Rights Reserved.</div>
       </div>
     </footer>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-    <script src="./js/main.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+    <script src="./js/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Refine head metadata with explicit title and description for portfolio site
- Link navigation and phone elements to real targets and add accessible telephone markup
- Enhance media: add alt text, responsive map wrapper, and defer JS for faster loading
- Ensure embedded Google Map stretches to the full height of the contact section and remains responsive on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edc27b810832881042bb0c1b5e0b4