### PR TITLE
Fix map height in contact section

### DIFF
--- a/contents/1/css/style.css
+++ b/contents/1/css/style.css
@@ -552,7 +552,7 @@ textarea {
 .map-wrap {
   position: relative;
   width: 100%;
-  padding-top: 56.25%;
+  height: 100%;
 }
 
 .map-wrap iframe {
@@ -582,6 +582,11 @@ textarea {
   }
   .contact {
     margin-top: 40px;
+  }
+
+  .map-wrap {
+    height: auto;
+    padding-top: 56.25%;
   }
 
   .map-wrap iframe {


### PR DESCRIPTION
## Summary
- Ensure embedded map expands to fill contact section on desktop
- Maintain a 16:9 aspect ratio for the map on smaller screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee7f3f068832884ded1e2eb3900a2